### PR TITLE
feat: add auth_token config and Bearer header injection ⚓

### DIFF
--- a/autonity_cli/__main__.py
+++ b/autonity_cli/__main__.py
@@ -3,10 +3,12 @@ Autonity RPC Client
 """
 
 import sys
+from typing import Optional
 
 from autonity.contracts.autonity import __version__ as protocol_version
 from click import group, option, version_option
 
+from . import config
 from .commands import (
     account,
     block,
@@ -23,11 +25,22 @@ from .logging import enable_logging
 
 @group(context_settings=dict(help_option_names=["-h", "--help"]))
 @option("--verbose", "-v", is_flag=True, help="Enable additional output (to stderr)")
+@option(
+    "--auth-token",
+    metavar="TOKEN",
+    help=(
+        "Bearer token for authenticated RPC endpoints "
+        f"(falls back to '{config.AUTH_TOKEN_ENV_VAR}' env var "
+        "or 'auth_token' in config file)."
+    ),
+)
 @version_option(message=f"Autonity CLI v%(version)s (Protocol {protocol_version})")
-def aut(verbose: bool) -> None:
+def aut(verbose: bool, auth_token: Optional[str]) -> None:
     """
     Command line interface to interact with Autonity.
     """
+
+    config.set_auth_token_from_cli(auth_token)
 
     if verbose:
         enable_logging()

--- a/autonity_cli/config.py
+++ b/autonity_cli/config.py
@@ -23,6 +23,48 @@ KEYFILE_PASSWORD_ENV_VAR = "KEYFILEPWD"
 WEB3_ENDPOINT_ENV_VAR = "WEB3_ENDPOINT"
 CONTRACT_ADDRESS_ENV_VAR = "CONTRACT_ADDRESS"
 CONTRACT_ABI_ENV_VAR = "CONTRACT_ABI"
+AUTH_TOKEN_ENV_VAR = "AUT_AUTH_TOKEN"
+
+_auth_token_cli: Optional[str] = None
+
+
+def set_auth_token_from_cli(token: Optional[str]) -> None:
+    """Set the auth token from the CLI --auth-token option."""
+    global _auth_token_cli
+    _auth_token_cli = token
+
+
+def _normalize_token(token: Optional[str]) -> Optional[str]:
+    """Strip whitespace; treat empty/whitespace-only as absent."""
+    if token is None:
+        return None
+    token = token.strip()
+    return token if token else None
+
+
+def get_auth_token() -> Optional[str]:
+    """
+    Get the auth token with CLI > env > config file precedence.
+    Returns None if no token is configured (backward compatible).
+    Empty or whitespace-only values at any level are treated as
+    absent, allowing fallthrough to the next source.
+    """
+    token = _normalize_token(_auth_token_cli)
+    if token is not None:
+        log("auth token configured (source: cli)")
+        return token
+
+    token = _normalize_token(os.getenv(AUTH_TOKEN_ENV_VAR))
+    if token is not None:
+        log("auth token configured (source: env)")
+        return token
+
+    token = _normalize_token(get_config_file().get("auth_token"))
+    if token is not None:
+        log("auth token configured (source: file)")
+        return token
+
+    return None
 
 
 def get_keystore_directory(keystore_directory: Optional[str]) -> str:

--- a/autonity_cli/utils.py
+++ b/autonity_cli/utils.py
@@ -31,6 +31,7 @@ from web3.types import (
 
 from . import config
 from .constants import COMMISSION_RATE_PRECISION, AutonDenoms
+from .logging import log
 from .denominations import NEWTON_DECIMALS
 from .keyfile import load_keyfile
 from .tx import (
@@ -77,13 +78,34 @@ def web3_provider_for_endpoint(endpoint: str) -> BaseProvider:
     Given an rpc endpoint, return an appropriate provider (https, ws,
     or IPC). If identifier isn't a valid format of one of these three
     types, throws an exception.
+
+    If an auth token is configured, injects a Bearer Authorization
+    header for HTTP providers. WebSocket and IPC providers do not
+    support custom headers.
     """
+    auth_token = config.get_auth_token()
+
     regex_http = re.compile(r"^(?:http)s?://")
     if re.match(regex_http, endpoint) is not None:
+        if auth_token is not None:
+            if endpoint.startswith("http://"):
+                log(
+                    "WARNING: sending auth token over plain HTTP. "
+                    "Consider using HTTPS for production endpoints."
+                )
+            return HTTPProvider(
+                endpoint,
+                request_kwargs={"headers": {"Authorization": f"Bearer {auth_token}"}},
+            )
         return HTTPProvider(endpoint)
 
     regex_ws = re.compile(r"^(?:ws)s?://")
     if re.match(regex_ws, endpoint) is not None:
+        if auth_token is not None:
+            log(
+                "WARNING: auth_token is set but WebSocket provider does not "
+                "support custom headers. Token will not be sent."
+            )
         return LegacyWebSocketProvider(endpoint)
 
     regex_ipc = re.compile("([^ !$`&*()+]|(\\[ !$`&*()+]))+\\.ipc")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,33 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
+from autonity_cli import config
+from autonity_cli import config_file
+from autonity_cli import logging as cli_logging
+
+
+def _clear_module_state() -> None:
+    """Reset all module-level globals to their defaults."""
+    config.set_auth_token_from_cli(None)
+    config_file.config_file_cached = False
+    config_file.config_file_data = config_file.ConfigFile({})
+    config_file.config_file_dir = "."
+    cli_logging.logging_enabled = False
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state(  # pyright: ignore[reportUnusedFunction]
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[None]:
+    """Reset module-level state and isolate from host environment."""
+    _clear_module_state()
+    monkeypatch.delenv(config.AUTH_TOKEN_ENV_VAR, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    yield
+    _clear_module_state()
+
 
 @pytest.fixture
 def runner() -> Iterator[CliRunner]:

--- a/tests/test_auth_token.py
+++ b/tests/test_auth_token.py
@@ -1,0 +1,142 @@
+"""Tests for auth_token configuration and HTTP header injection."""
+
+from collections.abc import Callable
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from web3 import HTTPProvider, IPCProvider, LegacyWebSocketProvider
+
+from autonity_cli import config
+from autonity_cli.utils import web3_provider_for_endpoint
+
+
+class TestGetAuthToken:
+    """Test auth token precedence: CLI > env > config file."""
+
+    def test_no_token_returns_none(self) -> None:
+        assert config.get_auth_token() is None
+
+    def test_cli_token(self) -> None:
+        config.set_auth_token_from_cli("cli-token")
+        assert config.get_auth_token() == "cli-token"
+
+    def test_env_token(self) -> None:
+        with patch.dict("os.environ", {"AUT_AUTH_TOKEN": "env-token"}):
+            assert config.get_auth_token() == "env-token"
+
+    def test_config_file_token(self, autrc: Callable[..., Path]) -> None:
+        autrc(auth_token="file-token")
+        assert config.get_auth_token() == "file-token"
+
+    def test_cli_beats_env(self) -> None:
+        config.set_auth_token_from_cli("cli-token")
+        with patch.dict("os.environ", {"AUT_AUTH_TOKEN": "env-token"}):
+            assert config.get_auth_token() == "cli-token"
+
+    def test_cli_beats_config_file(self, autrc: Callable[..., Path]) -> None:
+        autrc(auth_token="file-token")
+        config.set_auth_token_from_cli("cli-token")
+        assert config.get_auth_token() == "cli-token"
+
+    def test_env_beats_config_file(self, autrc: Callable[..., Path]) -> None:
+        autrc(auth_token="file-token")
+        with patch.dict("os.environ", {"AUT_AUTH_TOKEN": "env-token"}):
+            assert config.get_auth_token() == "env-token"
+
+    def test_empty_string_returns_none(self) -> None:
+        config.set_auth_token_from_cli("")
+        assert config.get_auth_token() is None
+
+    def test_whitespace_only_returns_none(self) -> None:
+        config.set_auth_token_from_cli("   ")
+        assert config.get_auth_token() is None
+
+    def test_whitespace_stripped(self) -> None:
+        config.set_auth_token_from_cli("  my-token  ")
+        assert config.get_auth_token() == "my-token"
+
+    def test_empty_env_falls_through_to_file(self, autrc: Callable[..., Path]) -> None:
+        """Empty/whitespace env var should fall through to config file."""
+        autrc(auth_token="file-token")
+        with patch.dict("os.environ", {"AUT_AUTH_TOKEN": "  "}):
+            assert config.get_auth_token() == "file-token"
+
+    def test_empty_cli_falls_through_to_env(self) -> None:
+        """Empty CLI value should fall through to env var."""
+        config.set_auth_token_from_cli("  ")
+        with patch.dict("os.environ", {"AUT_AUTH_TOKEN": "env-token"}):
+            assert config.get_auth_token() == "env-token"
+
+
+class TestProviderHeaderInjection:
+    """Test Bearer header injection in web3_provider_for_endpoint."""
+
+    def test_http_no_token(self) -> None:
+        provider = web3_provider_for_endpoint("https://rpc.example.com")
+        assert isinstance(provider, HTTPProvider)
+
+    def test_http_with_token(self) -> None:
+        config.set_auth_token_from_cli("my-jwt")
+        provider = web3_provider_for_endpoint("https://rpc.example.com")
+        assert isinstance(provider, HTTPProvider)
+        headers = provider._request_kwargs["headers"]  # type: ignore[attr-defined]
+        assert headers["Authorization"] == "Bearer my-jwt"
+
+    def test_plain_http_with_token_warns(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Plain HTTP + token should warn but still inject header."""
+        from autonity_cli.logging import enable_logging
+
+        enable_logging()
+        config.set_auth_token_from_cli("my-jwt")
+        provider = web3_provider_for_endpoint("http://localhost:8545")
+        assert isinstance(provider, HTTPProvider)
+        headers = provider._request_kwargs["headers"]  # type: ignore[attr-defined]
+        assert headers["Authorization"] == "Bearer my-jwt"
+        captured = capsys.readouterr()
+        assert "sending auth token over plain HTTP" in captured.err
+
+    def test_https_no_http_warning(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """HTTPS should not trigger plain HTTP warning."""
+        from autonity_cli.logging import enable_logging
+
+        enable_logging()
+        config.set_auth_token_from_cli("my-jwt")
+        provider = web3_provider_for_endpoint("https://rpc.example.com")
+        assert isinstance(provider, HTTPProvider)
+        captured = capsys.readouterr()
+        assert "sending auth token over plain HTTP" not in captured.err
+
+    def test_ws_with_token_warns(self, capsys: pytest.CaptureFixture[str]) -> None:
+        config.set_auth_token_from_cli("my-jwt")
+        # Enable logging so warning is emitted
+        from autonity_cli.logging import enable_logging
+
+        enable_logging()
+        provider = web3_provider_for_endpoint("ws://localhost:8546")
+        assert isinstance(provider, LegacyWebSocketProvider)
+        captured = capsys.readouterr()
+        assert "WebSocket provider does not support custom headers" in captured.err
+
+    def test_ws_no_token_no_warning(self, capsys: pytest.CaptureFixture[str]) -> None:
+        provider = web3_provider_for_endpoint("ws://localhost:8546")
+        assert isinstance(provider, LegacyWebSocketProvider)
+        captured = capsys.readouterr()
+        assert "WebSocket" not in captured.err
+
+    def test_ipc_with_token_silent(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """IPC + token should silently ignore the token, no warnings."""
+        from autonity_cli.logging import enable_logging
+
+        enable_logging()
+        config.set_auth_token_from_cli("my-jwt")
+        provider = web3_provider_for_endpoint("/tmp/node.ipc")
+        assert isinstance(provider, IPCProvider)
+        captured = capsys.readouterr()
+        assert "WARNING" not in captured.err
+
+    def test_invalid_endpoint_raises(self) -> None:
+        with pytest.raises(ValueError, match="cannot determine provider"):
+            web3_provider_for_endpoint("ftp://bad.endpoint")


### PR DESCRIPTION
## Summary

- Add `--auth-token TOKEN` CLI option on the `aut` group with CLI > `AUT_AUTH_TOKEN` env var > config file `auth_token` precedence
- Inject `Authorization: Bearer <token>` header at the single HTTP provider choke point (`web3_provider_for_endpoint`) — zero command file changes
- WebSocket: logs warning when token set but can't be sent; IPC: silently ignored
- Add autouse fixture in `conftest.py` to reset module-level auth state between tests

## Test plan

- [x] `hatch run test:all` — 4 existing tests pass
- [x] `hatch run lint:check-code` — ruff + black clean
- [x] `hatch run pyright` — no new errors (pre-existing `device.py` only)
- [x] `aut --help` — `--auth-token TOKEN` visible with fallback docs
- [ ] Manual: `aut -v --auth-token test node info` against authenticated endpoint shows `auth token configured (source: cli)` log

Refs #3