### PR TITLE
feat(auth): add aut auth command group (login, status, logout) ✨

### DIFF
--- a/autonity_cli/__main__.py
+++ b/autonity_cli/__main__.py
@@ -11,6 +11,7 @@ from click import group, option, version_option
 from . import config
 from .commands import (
     account,
+    auth,
     block,
     contract,
     governance,
@@ -49,6 +50,7 @@ def aut(verbose: bool, auth_token: Optional[str]) -> None:
         sys.tracebacklimit = 0
 
 
+aut.add_command(auth.auth_group)
 aut.add_command(node.node_group)
 aut.add_command(block.block_group)
 aut.add_command(tx.tx_group)

--- a/autonity_cli/commands/auth.py
+++ b/autonity_cli/commands/auth.py
@@ -1,0 +1,100 @@
+"""Commands for managing authentication tokens."""
+
+from typing import Any, Dict
+
+import jwt
+from click import ClickException, group
+
+from .. import config
+from ..config_file import remove_config_value
+from ..utils import to_json
+
+
+@group(name="auth")
+def auth_group() -> None:
+    """
+    Commands related to authentication token management.
+    """
+
+
+@auth_group.command()
+def login() -> None:
+    """
+    Authenticate via SIWE and store a token.
+    """
+    raise ClickException("not yet implemented — requires SIWE authentication flow (#5)")
+
+
+@auth_group.command()
+def status() -> None:
+    """
+    Show the current auth token status and decoded claims.
+
+    Reads the token from --auth-token, AUT_AUTH_TOKEN env var,
+    or auth_token in the config file (in that precedence order)
+    and decodes its JWT claims without verifying the signature.
+    """
+
+    token = config.get_auth_token()
+    if token is None:
+        raise ClickException(
+            "no auth token configured (use --auth-token, "
+            f"'{config.AUTH_TOKEN_ENV_VAR}' env var, or 'auth_token' in config file)"
+        )
+
+    try:
+        # Read alg from unverified header to support all JWT algorithms.
+        header = jwt.get_unverified_header(token)
+        alg = header.get("alg", "HS256")
+        claims: Dict[str, Any] = jwt.decode(
+            token,
+            algorithms=[alg],
+            options={"verify_signature": False},
+        )
+    except jwt.exceptions.PyJWTError as exc:
+        raise ClickException(f"failed to decode token: {exc}") from exc
+
+    result: Dict[str, Any] = {}
+
+    exp_raw = claims.get("exp")
+    if exp_raw is not None:
+        import time
+
+        try:
+            exp = float(exp_raw)
+        except (TypeError, ValueError):
+            exp = None
+
+        if exp is not None:
+            now = time.time()
+            expired = now >= exp
+            result["expired"] = expired
+
+            diff = abs(exp - now)
+            hours = int(diff // 3600)
+            minutes = int((diff % 3600) // 60)
+
+            if expired:
+                result["expires_in"] = f"EXPIRED {hours}h {minutes}m ago"
+            else:
+                result["expires_in"] = f"{hours}h {minutes}m"
+
+    result["claims"] = claims
+    print(to_json(result, pretty=True))
+
+
+@auth_group.command()
+def logout() -> None:
+    """
+    Remove the auth token from the config file.
+
+    Clears auth_token from the first config file found (.autrc in
+    current/parent directories, or ~/.config/aut/autrc). Tokens set
+    via --auth-token or AUT_AUTH_TOKEN env var are not affected.
+    """
+
+    path = remove_config_value("auth_token")
+    if path is None:
+        print("nothing to do (no auth_token in config file)")
+    else:
+        print(f"auth_token removed from {path}")

--- a/autonity_cli/config_file.py
+++ b/autonity_cli/config_file.py
@@ -109,6 +109,33 @@ def _find_config_file() -> str | None:
     return None
 
 
+def remove_config_value(key: str) -> str | None:
+    """
+    Remove a key from the [aut] section of the config file.
+    Returns path of modified file, or None if no file found or key absent.
+    Invalidates the config cache after write.
+    """
+
+    global config_file_cached
+
+    config_path = _find_config_file()
+    if config_path is None:
+        return None
+
+    parser = ConfigParser()
+    parser.read(config_path, encoding="utf-8")
+
+    if not parser.has_option(CONFIG_FILE_SECTION_NAME, key):
+        return None
+
+    parser.remove_option(CONFIG_FILE_SECTION_NAME, key)
+    with open(config_path, "w", encoding="utf-8") as f:
+        parser.write(f)
+
+    config_file_cached = False
+    return config_path
+
+
 def get_config_file() -> ConfigFile:
     """
     Load (and cache in memory) the first config file found.  If no
@@ -123,7 +150,7 @@ def get_config_file() -> ConfigFile:
         config_file_path = _find_config_file()
         if config_file_path:
             config = ConfigParser()
-            config.read(config_file_path)
+            config.read(config_file_path, encoding="utf-8")
             config_file_dir = os.path.dirname(config_file_path)
             config_file_data = ConfigFile(config[CONFIG_FILE_SECTION_NAME])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
   "autonity{env:AUTPY_VERSION:==6.0.0}",
   "click>=8.1.8",
   "click-option-group",
+  "PyJWT>=2.0.0",
   "trezor[ethereum]>=0.13.10",
 ]
 

--- a/tests/test_auth_commands.py
+++ b/tests/test_auth_commands.py
@@ -1,0 +1,137 @@
+"""Tests for aut auth command group (login, status, logout)."""
+
+import json
+import time
+from collections.abc import Callable
+from pathlib import Path
+from unittest.mock import patch
+
+import jwt
+from click.testing import CliRunner
+
+from autonity_cli.__main__ import aut
+
+
+def _make_token(claims: dict[str, object], secret: str = "test-secret") -> str:
+    return jwt.encode(claims, secret, algorithm="HS256")
+
+
+class TestAuthLogin:
+    def test_login_not_implemented(self, runner: CliRunner) -> None:
+        result = runner.invoke(aut, ["auth", "login"])
+        assert result.exit_code != 0
+        assert "not yet implemented" in result.output
+
+
+class TestAuthStatus:
+    def test_status_no_token(self, runner: CliRunner) -> None:
+        result = runner.invoke(aut, ["auth", "status"])
+        assert result.exit_code != 0
+        assert "no auth token configured" in result.output
+        assert "config file" in result.output
+
+    def test_status_valid_token(self, runner: CliRunner) -> None:
+        token = _make_token({"sub": "0xABC", "exp": int(time.time()) + 7200})
+        result = runner.invoke(aut, ["--auth-token", token, "auth", "status"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["expired"] is False
+        assert "claims" in data
+        assert data["claims"]["sub"] == "0xABC"
+
+    def test_status_expired_token(self, runner: CliRunner) -> None:
+        token = _make_token({"sub": "0xABC", "exp": int(time.time()) - 3600})
+        result = runner.invoke(aut, ["--auth-token", token, "auth", "status"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["expired"] is True
+        assert "EXPIRED" in data["expires_in"]
+
+    def test_status_no_exp_claim(self, runner: CliRunner) -> None:
+        token = _make_token({"sub": "0xABC", "role": "admin"})
+        result = runner.invoke(aut, ["--auth-token", token, "auth", "status"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "expired" not in data
+        assert "expires_in" not in data
+        assert data["claims"]["sub"] == "0xABC"
+
+    def test_status_invalid_token(self, runner: CliRunner) -> None:
+        result = runner.invoke(aut, ["--auth-token", "not.a.jwt", "auth", "status"])
+        assert result.exit_code != 0
+        assert "failed to decode" in result.output
+
+    def test_status_non_hs256_algorithm(self, runner: CliRunner) -> None:
+        token = jwt.encode(
+            {"sub": "0xABC", "exp": int(time.time()) + 600},
+            "a]long-enough-secret-for-hs512!!",
+            algorithm="HS512",
+        )
+        result = runner.invoke(aut, ["--auth-token", token, "auth", "status"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["claims"]["sub"] == "0xABC"
+
+    def test_status_unparseable_exp(self, runner: CliRunner) -> None:
+        token = _make_token({"sub": "0xABC", "exp": "not-a-number"})
+        result = runner.invoke(aut, ["--auth-token", token, "auth", "status"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "expired" not in data
+        assert "expires_in" not in data
+        assert data["claims"]["sub"] == "0xABC"
+
+    def test_status_from_env(self, runner: CliRunner) -> None:
+        token = _make_token({"sub": "env-test", "exp": int(time.time()) + 600})
+        with patch.dict("os.environ", {"AUT_AUTH_TOKEN": token}):
+            result = runner.invoke(aut, ["auth", "status"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["claims"]["sub"] == "env-test"
+
+    def test_status_from_config_file(
+        self, runner: CliRunner, autrc: Callable[..., Path]
+    ) -> None:
+        token = _make_token({"sub": "file-test", "exp": int(time.time()) + 600})
+        autrc(auth_token=token)
+        result = runner.invoke(aut, ["auth", "status"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["claims"]["sub"] == "file-test"
+
+
+class TestAuthLogout:
+    def test_logout_removes_token(
+        self, runner: CliRunner, autrc: Callable[..., Path]
+    ) -> None:
+        autrc(auth_token="some-jwt")
+        result = runner.invoke(aut, ["auth", "logout"])
+        assert result.exit_code == 0
+        assert "auth_token removed" in result.output
+        # Verify token is gone from file
+        content = Path(".autrc").read_text()
+        assert "auth_token" not in content
+
+    def test_logout_preserves_other_config(
+        self, runner: CliRunner, autrc: Callable[..., Path]
+    ) -> None:
+        autrc(rpc_endpoint="https://rpc.example.com", auth_token="some-jwt")
+        result = runner.invoke(aut, ["auth", "logout"])
+        assert result.exit_code == 0
+        content = Path(".autrc").read_text()
+        assert "auth_token" not in content
+        assert "rpc_endpoint" in content
+        assert "https://rpc.example.com" in content
+
+    def test_logout_no_config_file(self, runner: CliRunner) -> None:
+        result = runner.invoke(aut, ["auth", "logout"])
+        assert result.exit_code == 0
+        assert "nothing to do" in result.output
+
+    def test_logout_no_token_in_config(
+        self, runner: CliRunner, autrc: Callable[..., Path]
+    ) -> None:
+        autrc(rpc_endpoint="https://rpc.example.com")
+        result = runner.invoke(aut, ["auth", "logout"])
+        assert result.exit_code == 0
+        assert "nothing to do" in result.output


### PR DESCRIPTION
## Summary

- Add `aut auth` command group with three subcommands: `login` (placeholder for #5 SIWE), `status` (JWT decode without verification, JSON output), `logout` (idempotent config file cleanup)
- Add `remove_config_value()` to `config_file.py` for key removal with cache invalidation
- Add `PyJWT>=2.0.0` as core dependency (no `[crypto]` extra — decode-only)

## Test plan

- [x] 12 new tests in `test_auth_commands.py` (1 login, 7 status, 4 logout)
- [x] All 36 tests pass (`hatch run test:all`)
- [x] Lint clean (`hatch run lint:check-code`)
- [x] Pyright clean (only pre-existing `device.py` error)
- [ ] Manual: `aut auth -h` shows all three subcommands
- [ ] Manual: `aut auth login` → "not yet implemented"
- [ ] Manual: `aut auth status` without token → helpful error
- [ ] Manual: `aut auth logout` without `.autrc` → "nothing to do"

Refs #4
