### PR TITLE
docs(auth): add README section and CHANGELOG entries 📝

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,24 @@ Template:
 ### Fixed
 -->
 
+## [Unreleased]
+
+### Added
+
+- JWT-authenticated RPC access via Sign-In with Ethereum (SIWE) ([#11](https://github.com/Klazomenai/autonity-cli/pull/11), [#13](https://github.com/Klazomenai/autonity-cli/pull/13))
+- `aut auth login`, `aut auth status`, `aut auth logout` commands ([#12](https://github.com/Klazomenai/autonity-cli/pull/12))
+- `auth_token` and `auth_service` configuration fields ([#11](https://github.com/Klazomenai/autonity-cli/pull/11))
+- JWT authentication guide in `docs/auth.md` ([#20](https://github.com/Klazomenai/autonity-cli/pull/20))
+
+### Fixed
+
+- Authenticated RPC requests fail with 415 on Web3.py 7.x due to missing `Content-Type` header ([#18](https://github.com/Klazomenai/autonity-cli/pull/18))
+- Login fails when auth service returns `parent_token` field ([#16](https://github.com/Klazomenai/autonity-cli/pull/16))
+
+### Changed
+
+- Test framework migrated from unittest to pytest ([#10](https://github.com/Klazomenai/autonity-cli/pull/10))
+
 ## [v2.0.2] - 2025-08-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,21 +22,21 @@ Template:
 
 ## [Unreleased]
 
+### Changed
+
+- Test framework migrated from unittest to pytest
+
 ### Added
 
-- JWT-authenticated RPC access via Sign-In with Ethereum (SIWE) ([#11](https://github.com/Klazomenai/autonity-cli/pull/11), [#13](https://github.com/Klazomenai/autonity-cli/pull/13))
-- `aut auth login`, `aut auth status`, `aut auth logout` commands ([#12](https://github.com/Klazomenai/autonity-cli/pull/12))
-- `auth_token` and `auth_service` configuration fields ([#11](https://github.com/Klazomenai/autonity-cli/pull/11))
-- JWT authentication guide in `docs/auth.md` ([#20](https://github.com/Klazomenai/autonity-cli/pull/20))
+- JWT-authenticated RPC access via Sign-In with Ethereum (SIWE)
+- `aut auth login`, `aut auth status`, `aut auth logout` commands
+- `auth_token` and `auth_service` configuration fields
+- JWT authentication guide in `docs/auth.md`
 
 ### Fixed
 
-- Authenticated RPC requests fail with 415 on Web3.py 7.x due to missing `Content-Type` header ([#18](https://github.com/Klazomenai/autonity-cli/pull/18))
-- Login fails when auth service returns `parent_token` field ([#16](https://github.com/Klazomenai/autonity-cli/pull/16))
-
-### Changed
-
-- Test framework migrated from unittest to pytest ([#10](https://github.com/Klazomenai/autonity-cli/pull/10))
+- Authenticated RPC requests fail with 415 on Web3.py 7.x due to missing `Content-Type` header
+- Login fails when auth service returns `parent_token` field
 
 ## [v2.0.2] - 2025-08-12
 
@@ -144,6 +144,7 @@ Template:
 - Fix startup crash due to `ModuleNotFoundError` from eth_rlp ([#137](https://github.com/autonity/autonity-cli/issues/137))
 
 <!-- [vX.Y.Z]: https://github.com/autonity/autonity.py/releases/tag/vX.Y.Z -->
+[Unreleased]: https://github.com/autonity/autonity-cli/compare/v2.0.2...HEAD
 [v2.0.2]: https://github.com/autonity/autonity-cli/releases/tag/v2.0.2
 [v2.0.1]: https://github.com/autonity/autonity-cli/releases/tag/v2.0.1
 [v2.0.0]: https://github.com/autonity/autonity-cli/releases/tag/v2.0.0

--- a/README.md
+++ b/README.md
@@ -103,6 +103,27 @@ password to decrypt the key. But if the environment variable `KEYFILEPWD` has
 been set, then Autonity CLI will skip the password prompt and attempt to use the
 value of this variable as the keyfile password instead.
 
+### JWT-authenticated RPC
+
+For RPC endpoints protected by JWT access control (e.g. via
+[KeyRA](https://github.com/Klazomenai/KeyRA)), `aut` supports Sign-In with
+Ethereum ([SIWE](https://eips.ethereum.org/EIPS/eip-4361)) authentication:
+
+```console
+$ aut auth login \
+    --keyfile ~/.autonity/keystore/mykey.json \
+    --auth-service https://your-keyra-instance.example.com
+logged in as 0xYourAddress
+token stored in /path/to/.autrc
+```
+
+Once authenticated, the JWT is automatically included as a `Bearer` token on
+all HTTP RPC requests. Use `aut auth status` to inspect the token and
+`aut auth logout` to remove it.
+
+See [docs/auth.md](docs/auth.md) for the full guide including configuration
+reference, protocol-specific behaviour, and troubleshooting.
+
 ## (Optional) Enable command completion (bash and zsh)
 
 Completion is available in `bash` and `zsh` shells as follows. (Adapt these

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ and transactions:
 - Trezor device
 - local keyfile
 
+It also supports JWT-authenticated RPC access via Sign-In with Ethereum (SIWE)
+for endpoints that require token-based access control. See the
+[JWT-authenticated RPC](#jwt-authenticated-rpc) section below.
+
 ### Trezor authentication
 
 Before using a Trezor device with Autonity CLI, ensure it is running the latest


### PR DESCRIPTION
## Summary

- Add "JWT-authenticated RPC" subsection to README.md under the existing Authentication section, with a quick start example and cross-reference to `docs/auth.md`
- Update Authentication section intro to mention JWT alongside Trezor/keyfile
- Add `[Unreleased]` section to CHANGELOG.md covering all auth-related work in Common Changelog format

### Motivation

PR #20 delivered `docs/auth.md` but the README had no entry point for JWT auth — users installing via `pipx` would not discover the feature from the README alone. The CHANGELOG also had no record of the auth work shipped across the fork's auth PRs.

Refs #9

## Test plan

- [x] README JWT section renders correctly on GitHub (heading level, code block, links)
- [x] README Authentication intro mentions all three auth methods (Trezor, keyfile, JWT)
- [x] CHANGELOG `[Unreleased]` section follows Common Changelog format (section order, no links until upstreamed)
- [x] `[Unreleased]` link definition resolves to upstream compare URL
- [x] No private infrastructure references in either file
- [x] README example uses generic placeholder URLs consistent with `docs/auth.md`